### PR TITLE
fix error message when compiling the text "3[ 1 2 3 ] 3[ 1 2 3 ]"

### DIFF
--- a/jianpu-ly.py
+++ b/jianpu-ly.py
@@ -326,7 +326,7 @@ class notehead_markup:
         ret += ']'
         self.inBeamGroup = 'restHack'
     self.lastNBeams = nBeams
-    if self.barPos == self.barLength:
+    if abs(self.barLength - self.barPos) < 0.001:
         self.barPos = 0 ; self.barNo += 1
         self.current_accidentals = {}
     # Octave dots:


### PR DESCRIPTION
Hi ,
When I compile jianpu text "**3[ 1 2 3 ] 3[ 1 2 3 ]**" with jianpu-ly.py v1.3, I got error message like this "**ERROR: Incomplete bar at end of score 1 ( pos 63, should be 0)**".