### PR TITLE
add shorthand for fingering notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ Other Lilypond code: `LP: (block of code) :LP` (each delimeter at start of its l
 
 Ignored: `% a comment`
 
+Erhu fingering shorthand (appears over previous note): `Fr=0 Fr=1 Fr=2 Fr=3 Fr=4`
+
+Erhu expression symbols (appears over previous note):
+```
+# Souyin
+Fr=久
+
+# Harmonic
+Fr=○
+
+# Pitch bends
+Fr=⤻ Fr=𝀈 Fr=↗ Fr=↘
+```
+
 
 Copyright and Trademarks
 ------------------------

--- a/jianpu-ly.py
+++ b/jianpu-ly.py
@@ -125,7 +125,7 @@ def all_scores_start(staff_size = 20):
   score-system-spacing = #'((basic-distance . 9) (padding . 5) (stretchability . 1e7))
   markup-system-spacing = #'((basic-distance . 2) (padding . 2) (stretchability . 0))
 """
-    return r+"}\n"
+    return r+"\n}\n"
 
 def score_start():
     ret = "\\score {\n"
@@ -681,6 +681,10 @@ def getLY(score):
                     out.append(r"\transpose c "+transposeTo+r" { \key c \major ") # so that MIDI or Western pitches are correct
                     inTranspose = 1
                 else: out.append(r'\mark \markup{%s}' % word.replace("b",r"\flat").replace("#",r"\sharp"))
+            elif word.startswith("Fr="):
+              finger = str(word.split("=")[1])
+              finger = {"1": "–", "2": "=", "3": "≡", "4": "四"}.get(finger, finger)
+              out.append(r'\finger "%s"' % finger)
             elif re.match("[1-9][0-9]*/[1-468]+(,[1-9][0-9]*[.]?)?$",word): # time signature
                 if ',' in word: # anacrusis
                     word,anac = word.split(",",1)


### PR DESCRIPTION
Hi Silas, thanks for the work on jianpu-ly! I am using it to create scores for the erhu. Since erhu scores have many expression symbols and often annotate fingering, I found myself writing some lilypond syntax and custom LP blocks. It was convenient to have a fingering shorthand in the jianpu-ly syntax and to have the expression symbols documented for easy copy-pasting.

I realize this may be more specific to the erhu, but maybe this kind of idea could be useful to others.

```
% pitch and slides
1, Fr=𝀈 2, Fr=↗ 3 Fr=↘ 4
LP:
\finger \markup \bold \large "𝁜"
:LP

% souyin 久, bend, harmonic
2 Fr=久 3 Fr=⤻ 1 Fr=○
-

% fingering
1 Fr=0 2 Fr=1 3 Fr=2 4 Fr=3
5 Fr=4 6 Fr=1 7 Fr=2 1, Fr=3
```
![image](https://user-images.githubusercontent.com/476374/196067898-9af4f7fd-ed85-4abe-ac99-b8d29d7ea764.png)
