### PR TITLE
Support Multibar Rests from MusicXML

### DIFF
--- a/jianpu-ly.py
+++ b/jianpu-ly.py
@@ -4,7 +4,7 @@
 
 r"""
 # Jianpu (numbered musical notaion) for Lilypond
-# v1.874 (c) 2012-2026 Silas S. Brown
+# v1.875 (c) 2012-2026 Silas S. Brown
 # v1.826 (c) 2024 Unbored
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1108,16 +1108,16 @@ def xml2jianpu(x):
     partList=[""];time=["4","4"];tempo=["",""]
     note=[[""]*11];keySig=[['']*7];barSig=[['']*7,None];note1=["C"]
     tSig=[None,0];prevChord=[None,None]
-    multiple_rest_count = 0
-    multiple_rest_total = 0
-    skip_mrest = False
-    mrest_text_buffer = ""
+    class MultiRest:
+        def __init__(self):
+            self.count = self.total = 0
+            self.skip, self.buffer = False,""
+    multiple_rest = MultiRest()
     types={"64th":"h","32nd":"d","16th":"s","eighth":"q","quarter":"","half":" -","whole":" - - -"}
     typesDot={"64th":"h.","32nd":"d.","16th":"s.","eighth":"q.","quarter":".","half":" - -","whole":" - - - - -"}
     typesMM={"64th":"64","32nd":"32","16th":"16","eighth":"8","quarter":"4","half":"2","whole":"1"}
     quavers={"64th":0.125,"32nd":0.25,"16th":0.5,"eighth":1,"quarter":2,"half":4,"whole":8}
     def s(name,attrs):
-        nonlocal multiple_rest_count, multiple_rest_total, skip_mrest, mrest_text_buffer
         dat[0],dat[1]="",attrs
         if name=="measure":
             oldBarsig = barSig[0]
@@ -1125,7 +1125,6 @@ def xml2jianpu(x):
             if barSig[1] is not None: barSig[0][barSig[1]]=oldBarsig[barSig[1]] # for tie
     def c(data): dat[0] += data
     def e(name):
-        nonlocal multiple_rest_count, multiple_rest_total, skip_mrest, mrest_text_buffer
         d0 = dat[0].strip()
         if name in ['work-title','movement-title'] or name=='credit-words' and dat[1].get("justify","")=="center":
             if not(any(r.startswith("title=") for r in ret)):
@@ -1192,17 +1191,16 @@ def xml2jianpu(x):
                 for n,p in enumerate(tSig[0][1:]):
                     if not p is None: partsInProgress[n][p]+=a
             tSig[0]=None
-        # Handle multibar rest from <multiple-rest> element (always on measure close)
-        if name=="measure" and multiple_rest_count > 0:
-            multiple_rest_count -= 1
-            if multiple_rest_count == 0:
-                partsInProgress[0].append('R*' + str(multiple_rest_total))
-                if mrest_text_buffer:
-                    partsInProgress[0].append(mrest_text_buffer.strip())
-                    mrest_text_buffer = ""
-                skip_mrest = False
-                multiple_rest_count = 0
-                multiple_rest_total = 0
+        # Handle multibar rest from <multiple-rest> element (always on measure close) (contributed by Eagle Wu)
+        if name=="measure" and multiple_rest.count > 0:
+            multiple_rest.count -= 1
+            if multiple_rest.count == 0:
+                partsInProgress[0].append('R*' + str(multiple_rest.total))
+                if multiple_rest.buffer:
+                    partsInProgress[0].append(multiple_rest.buffer.strip())
+                    multiple_rest.buffer = ""
+                multiple_rest.skip = False
+                multiple_rest.count = multiple_rest.total = 0
         elif name=="beat-unit": tempo[0]=typesMM.get(name,"4")
         elif name=="beat-minute" or name=="per-minute": tempo[1]=d0
         elif name=="metronome":
@@ -1216,9 +1214,8 @@ def xml2jianpu(x):
             text = dat[0].strip() if dat[0] else ""
             if text:
                 try:
-                    multiple_rest_total = int(text)
-                    multiple_rest_count = multiple_rest_total
-                    skip_mrest = True
+                    multiple_rest.count = multiple_rest.total = int(text)
+                    multiple_rest.skip = True
                 except ValueError:
                     pass
         elif name=="rest": note[0][0]="r"
@@ -1242,12 +1239,9 @@ def xml2jianpu(x):
         elif name in "ppppp pppp ppp pp p mp mf f ff fff ffff fffff fp sf sfz n rfz mordent accent tenuto turn marcato staccatissimo fermata staccato stopped open".split(): note[0][5] += " \\"+name # element names that exactly equal their corresponding no-parameter Lilypond commands
         elif name=="words":
             toAdd = r' ^"'+dat[0].strip().replace('"',"'")+'"'
-            if skip_mrest:
-                mrest_text_buffer += toAdd
-            else:
-                if not toAdd in note[0][5]: note[0][5] += toAdd
-        elif name=="note":
-            if skip_mrest: return
+            if multiple_rest.skip: multiple_rest.buffer += toAdd
+            elif not toAdd in note[0][5]: note[0][5] += toAdd
+        elif name=="note" and not multiple_rest.skip:
             # Try to find which voice it goes onto, if we're MuseScore
             # or similar and have parts as voices within a part.
             # TODO: sometimes the XML will give us a voice or staff number; for now we just find the first one to fit

--- a/jianpu-ly.py
+++ b/jianpu-ly.py
@@ -1108,11 +1108,16 @@ def xml2jianpu(x):
     partList=[""];time=["4","4"];tempo=["",""]
     note=[[""]*11];keySig=[['']*7];barSig=[['']*7,None];note1=["C"]
     tSig=[None,0];prevChord=[None,None]
+    multiple_rest_count = 0
+    multiple_rest_total = 0
+    skip_mrest = False
+    mrest_text_buffer = ""
     types={"64th":"h","32nd":"d","16th":"s","eighth":"q","quarter":"","half":" -","whole":" - - -"}
     typesDot={"64th":"h.","32nd":"d.","16th":"s.","eighth":"q.","quarter":".","half":" - -","whole":" - - - - -"}
     typesMM={"64th":"64","32nd":"32","16th":"16","eighth":"8","quarter":"4","half":"2","whole":"1"}
     quavers={"64th":0.125,"32nd":0.25,"16th":0.5,"eighth":1,"quarter":2,"half":4,"whole":8}
     def s(name,attrs):
+        nonlocal multiple_rest_count, multiple_rest_total, skip_mrest, mrest_text_buffer
         dat[0],dat[1]="",attrs
         if name=="measure":
             oldBarsig = barSig[0]
@@ -1120,6 +1125,7 @@ def xml2jianpu(x):
             if barSig[1] is not None: barSig[0][barSig[1]]=oldBarsig[barSig[1]] # for tie
     def c(data): dat[0] += data
     def e(name):
+        nonlocal multiple_rest_count, multiple_rest_total, skip_mrest, mrest_text_buffer
         d0 = dat[0].strip()
         if name in ['work-title','movement-title'] or name=='credit-words' and dat[1].get("justify","")=="center":
             if not(any(r.startswith("title=") for r in ret)):
@@ -1180,12 +1186,23 @@ def xml2jianpu(x):
             mxlPosition[0] += mxlPosition[1]
             mxlPosition[1] = 0
         elif name=="measure" and not tSig[0]==None:
-            if not tSig[1]==int(time[0])*8/int(time[1]):
+            if not tSig[1]==int(time[0])*8/int(time[1]) and tSig[1]>0:
                 a = ","+{0.5:"16",0.75:"16.",1:"8",1.5:"8.",2:"4",3:"4.",4:"2",6:"2.",8:"1",12:"1."}[tSig[1]] # anacrusis
                 paddingRestList[tSig[0][0]] += a
                 for n,p in enumerate(tSig[0][1:]):
                     if not p is None: partsInProgress[n][p]+=a
             tSig[0]=None
+        # Handle multibar rest from <multiple-rest> element (always on measure close)
+        if name=="measure" and multiple_rest_count > 0:
+            multiple_rest_count -= 1
+            if multiple_rest_count == 0:
+                partsInProgress[0].append('R*' + str(multiple_rest_total))
+                if mrest_text_buffer:
+                    partsInProgress[0].append(mrest_text_buffer.strip())
+                    mrest_text_buffer = ""
+                skip_mrest = False
+                multiple_rest_count = 0
+                multiple_rest_total = 0
         elif name=="beat-unit": tempo[0]=typesMM.get(name,"4")
         elif name=="beat-minute" or name=="per-minute": tempo[1]=d0
         elif name=="metronome":
@@ -1195,6 +1212,15 @@ def xml2jianpu(x):
                         p.append("=".join(tempo)) ; break
             tempo[0]=tempo[1]="" # for now we ignore <metronome> elements that don't specify all parameters
         elif name=="step": note[0][0]=d0
+        elif name=="multiple-rest":
+            text = dat[0].strip() if dat[0] else ""
+            if text:
+                try:
+                    multiple_rest_total = int(text)
+                    multiple_rest_count = multiple_rest_total
+                    skip_mrest = True
+                except ValueError:
+                    pass
         elif name=="rest": note[0][0]="r"
         elif name=="octave": note[0][1]=int(d0)
         elif name=="accidental": note[0][2]=d0
@@ -1216,8 +1242,12 @@ def xml2jianpu(x):
         elif name in "ppppp pppp ppp pp p mp mf f ff fff ffff fffff fp sf sfz n rfz mordent accent tenuto turn marcato staccatissimo fermata staccato stopped open".split(): note[0][5] += " \\"+name # element names that exactly equal their corresponding no-parameter Lilypond commands
         elif name=="words":
             toAdd = r' ^"'+dat[0].strip().replace('"',"'")+'"'
-            if not toAdd in note[0][5]: note[0][5] += toAdd
+            if skip_mrest:
+                mrest_text_buffer += toAdd
+            else:
+                if not toAdd in note[0][5]: note[0][5] += toAdd
         elif name=="note":
+            if skip_mrest: return
             # Try to find which voice it goes onto, if we're MuseScore
             # or similar and have parts as voices within a part.
             # TODO: sometimes the XML will give us a voice or staff number; for now we just find the first one to fit


### PR DESCRIPTION
This Commit handles <multiple-rest> element in MusicXML and outputs multiple rests in jianpu-ly.

Test file for multiple rest MusicXML:
[test-multirests.xml](https://github.com/user-attachments/files/30593301/test-multirests.xml)
