### PR TITLE
Fix arpeggio chord processing: handle missing whitespace and concatenate chord notes

### DIFF
--- a/jianpu-ly.py
+++ b/jianpu-ly.py
@@ -1410,12 +1410,18 @@ def xml2jianpu(x):
                     ourRet[-1]=ourRet[-1][:i]+"&"+r+ourRet[-1][i:]
                 else:
                     rr = state.prevChordNList[state.prevChordOffset]
-                    chord,dashes = rr.split(None,1)
-                    if chord in ('arpUp','arpDown','arp'): arp,(chord,dashes)=chord+" ",dashes.split(None,1)
+                    parts = rr.split(None,1)
+                    if len(parts) < 2: chord,dashes = rr,''
+                    else: chord,dashes = parts
+                    if chord in ('arpUp','arpDown','arp'):
+                        arpParts = dashes.split(None,1)
+                        arp=chord+" "
+                        chord=arpParts[0]
+                        dashes=arpParts[1] if len(arpParts)>1 else ''
                     else: arp=""
                     if dashes: dashes=" "+dashes
-                    state.prevChordNList[state.prevChordOffset] = arp+(tremolo if not tremolo in rr else '')+chord+dashes
-                return
+                    state.prevChordNList[state.prevChordOffset] = arp+(tremolo if not tremolo in rr else '')+chord+r+dashes
+                    return
             if tState=="start":
                 ourRet.append(tuplet+"[")
                 if ourI==0: paddingRestList.append(tuplet+"[")

--- a/jianpu-ly.py
+++ b/jianpu-ly.py
@@ -4,7 +4,7 @@
 
 r"""
 # Jianpu (numbered musical notaion) for Lilypond
-# v1.882 (c) 2012-2026 Silas S. Brown
+# v1.883 (c) 2012-2026 Silas S. Brown
 # v1.826 (c) 2024 Unbored
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -960,7 +960,7 @@ class NoteheadMarkup:
         else:
             ret = r" \jianpuGraceCurveEnd " + ret 
     # sys.stderr.write(accidental+figure+octave+dots+"/"+str(nBeams)+"->"+str(self.barPos)+" ") # if need to see where we are
-    if self.pendingArp: ret += r"\arpeggio "; self.pendingArp = 0
+    if self.pendingArp: ret,self.pendingArp = ret+r"\arpeggio ",0
     if self.barPos > self.barLength: errExit("(notesHad=%s) barcheck fail: note crosses barline at \"%s\" with %d beams (%d skipped from %d to %d, bypassing %d), scoreNo=%d barNo=%d (but the error could be earlier)" % (' '.join(self.notesHad),figures,nBeams,toAdd,self.barPos-toAdd,self.barPos,self.barLength,scoreNo,self.barNo))
     if (self.barPos%self.beatLength == 0 or self.barPos==self.barLength) and self.inBeamGroup: # (or added for irregular time signatures; self.inBeamGroup is set only if not midi/western)
         # jianpu printouts tend to restart beams every beat
@@ -1405,24 +1405,17 @@ def xml2jianpu(x):
                 state.barTied=(dTone%7) if tie else None
                 if state.keySig[dTone%7]=="#": acc="" if acc=="#" else "b"
                 if state.keySig[dTone%7]=="b": acc="" if acc=="b" else "#"
-            if chord:
-                if grace:
-                    i=ourRet[-1].rindex("]")
-                    ourRet[-1]=ourRet[-1][:i]+"&"+r+ourRet[-1][i:]
-                else:
-                    rr = state.prevChordNList[state.prevChordOffset]
-                    parts = rr.split(None,1)
-                    if len(parts) < 2: chord,dashes = rr.strip(),' '
-                    else: chord,dashes = parts
-                    if chord in ('arpUp','arpDown','arp'):
-                        arpParts = dashes.split(None,1)
-                        arp=chord+" "
-                        chord=arpParts[0]
-                        dashes=arpParts[1].rstrip() if len(arpParts)>1 else ''
-                    else: arp=""
-                    if dashes: dashes=" "+dashes
-                    state.prevChordNList[state.prevChordOffset] = arp+(tremolo if not tremolo in rr else '')+chord+r+dashes
-                    return
+            if chord and grace:
+                i=ourRet[-1].rindex("]")
+                ourRet[-1]=ourRet[-1][:i]+"&"+r+ourRet[-1][i:]
+                return
+            elif chord:
+                rr = state.prevChordNList[state.prevChordOffset]
+                arp,chord,dashes = rr.split(" ",2)
+                if arp: arp += " "
+                if dashes: dashes=" "+dashes.rstrip()
+                state.prevChordNList[state.prevChordOffset] = arp+(tremolo if not tremolo in rr else '')+chord+r+dashes
+                return
             if tState=="start":
                 ourRet.append(tuplet+"[")
                 if ourI==0: paddingRestList.append(tuplet+"[")
@@ -1461,7 +1454,7 @@ def xml2jianpu(x):
             if state.pendingWedgeCmd:
                 extras = extras+' '+state.pendingWedgeCmd
                 state.pendingWedgeCmd = ""
-            ourRet.append((arpeggio+' ' if arpeggio else '')+w1+extras+' '+w2+' '+tie)
+            ourRet.append(arpeggio+' '+w1+extras+' '+w2+' '+tie)
             if tState=="stop":
                 ourRet.append("]")
                 if ourI==0: paddingRestList.append("]")

--- a/jianpu-ly.py
+++ b/jianpu-ly.py
@@ -960,7 +960,7 @@ class NoteheadMarkup:
         else:
             ret = r" \jianpuGraceCurveEnd " + ret 
     # sys.stderr.write(accidental+figure+octave+dots+"/"+str(nBeams)+"->"+str(self.barPos)+" ") # if need to see where we are
-    if self.pendingArp: ret += r"\arpeggio "
+    if self.pendingArp: ret += r"\arpeggio "; self.pendingArp = 0
     if self.barPos > self.barLength: errExit("(notesHad=%s) barcheck fail: note crosses barline at \"%s\" with %d beams (%d skipped from %d to %d, bypassing %d), scoreNo=%d barNo=%d (but the error could be earlier)" % (' '.join(self.notesHad),figures,nBeams,toAdd,self.barPos-toAdd,self.barPos,self.barLength,scoreNo,self.barNo))
     if (self.barPos%self.beatLength == 0 or self.barPos==self.barLength) and self.inBeamGroup: # (or added for irregular time signatures; self.inBeamGroup is set only if not midi/western)
         # jianpu printouts tend to restart beams every beat
@@ -1217,6 +1217,7 @@ def xml2jianpu(x):
             paddingRestDict[0] = 0
             state.mvtLastBarNo = None ; state.mvtBreakIndicators = set()
             state.mvtBarLockedIndices = None ; state.breakCount = 0
+            state.prevChordOffset = None ; state.prevChordNList = None
             if partList: del partList[0]
         elif name=="fifths":
             state.keySig=['']*7
@@ -1411,13 +1412,13 @@ def xml2jianpu(x):
                 else:
                     rr = state.prevChordNList[state.prevChordOffset]
                     parts = rr.split(None,1)
-                    if len(parts) < 2: chord,dashes = rr,''
+                    if len(parts) < 2: chord,dashes = rr.strip(),' '
                     else: chord,dashes = parts
                     if chord in ('arpUp','arpDown','arp'):
                         arpParts = dashes.split(None,1)
                         arp=chord+" "
                         chord=arpParts[0]
-                        dashes=arpParts[1] if len(arpParts)>1 else ''
+                        dashes=arpParts[1].rstrip() if len(arpParts)>1 else ''
                     else: arp=""
                     if dashes: dashes=" "+dashes
                     state.prevChordNList[state.prevChordOffset] = arp+(tremolo if not tremolo in rr else '')+chord+r+dashes


### PR DESCRIPTION
## Fix arpeggio chord processing (commit `c0196e7` follow-up)

The refactor at `c0196e7` introduced two bugs in chord processing when arpeggio keywords are present:

1. **Missing `+r+`**: The new note character was never concatenated to the chord entry, so chord notes appeared as separate entries instead of combined (e.g., `arpDown 2,,` instead of `arpDown 2,,6,,2,246`)

2. **Unpacking assumptions**: Both `rr.split(None,1)` and `dashes.split(None,1)` assumed 2 values, but fail when there's no whitespace or only one part (e.g., single-note chords or entries without tie information)

### Fix

Added defensive checks for both cases:
- Check `len(parts) < 2` before unpacking `rr.split(None,1)`
- Check `len(arpParts) > 1` before accessing second element of `dashes.split(None,1)`
- Added missing `+r+` to concatenate chord notes